### PR TITLE
Updated module registration instruction as per VSF 1.12 inreadme.md file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ export function registerClientModules () {
 }
 ```
 
-
-
 Add the endpoint to your config
 ```json
   "braintree" : {

--- a/README.md
+++ b/README.md
@@ -11,18 +11,33 @@ By hand (preferer):
 $ git clone git@github.com:danrcoull/vsf-payment-braintree.git ./vue-storefront/src/modules/payment-braintree
 ```
 
-Registration the Braintree module. Go to `./src/modules/index.ts`
+Registration the Braintree module. Go to `./src/modules/client.ts`
 ```js
 ...
-import { GoogleAnalytics } from './google-analytics';
+import { InitialResourcesModule } from '@vue-storefront/core/modules/initial-resources'
 import { Braintree } from './payment-braintree';
 
-export const registerModules: VueStorefrontModule[] = [
+export function registerNewModules () {
   ...
-  GoogleAnalytics,
-  Braintree
+  registerModule(InstantCheckoutModule) 
+  registerModule(Braintree) 
 ]
 ```
+
+OR If you use Capybara VS theme. Go to `./src/themes/capybara/config/modules.ts`
+```js
+...
+import { PaymentCashOnDeliveryModule } from 'src/modules/payment-cash-on-delivery'
+import { Braintree } from 'src/modules/payment-braintree'
+...
+export function registerClientModules () {
+  ...
+  registerModule(NewsletterModule)
+  registerModule(Braintree)
+}
+```
+
+
 
 Add the endpoint to your config
 ```json


### PR DESCRIPTION
Updated module registration instruction as per VSF 1.12 in README.md file
As per VSF1.12 we have src/modules/client.ts file for module registration, also we can register modules in theme as well.
Added instruction to add module in theme.